### PR TITLE
feat(@grail-ui/svelte): tabs support generic for value

### DIFF
--- a/.changeset/gorgeous-hotels-heal.md
+++ b/.changeset/gorgeous-hotels-heal.md
@@ -1,0 +1,5 @@
+---
+'@grail-ui/svelte': minor
+---
+
+Tabs support generic for `value`

--- a/apps/docs/src/lib/modules/tabs/demos/TabsDemo.svelte
+++ b/apps/docs/src/lib/modules/tabs/demos/TabsDemo.svelte
@@ -13,7 +13,6 @@
 >
 	<div {...$listAttrs} class="flex flex-wrap border-b-2 border-gray-300">
 		<button {...$triggerAttrs('tab1')}>Recent</button>
-
 		<button {...$triggerAttrs('tab2')}>Popular</button>
 		<button {...$triggerAttrs('tab3')}>Trending</button>
 	</div>

--- a/packages/grail-ui/src/tabs/tabs.types.ts
+++ b/packages/grail-ui/src/tabs/tabs.types.ts
@@ -1,16 +1,16 @@
 import type { Action } from 'svelte/action';
 import type { Readable } from 'svelte/store';
 
-export interface TabsConfig {
+export interface TabsConfig<T extends string = string> {
 	/**
 	 * Initial value (controls active state of tabs).
 	 */
-	defaultValue?: string;
+	defaultValue?: T;
 
 	/**
 	 * Event handler called when the active state of the tabs changes.
 	 */
-	onValueChange?: (value: string) => void;
+	onValueChange?: (value: T) => void;
 
 	/**
 	 * The tabs orientation. Affects arrow navigation.
@@ -27,13 +27,13 @@ export interface TabsConfig {
 	activationMode?: 'automatic' | 'manual';
 }
 
-export type TabsParams = Pick<TabsConfig, 'activationMode'>;
+export type TabsParams<T extends string> = Pick<TabsConfig<T>, 'activationMode'>;
 
-export interface TabsTriggerParams {
+export interface TabsTriggerParams<T extends string> {
 	/**
 	 * A unique identifier that associates the trigger with a content.
 	 */
-	value: string;
+	value: T;
 
 	/**
 	 * Prevents the user from interacting with the tab.
@@ -43,28 +43,28 @@ export interface TabsTriggerParams {
 	disabled?: boolean;
 }
 
-export interface TabsContentParams {
+export interface TabsContentParams<T extends string> {
 	/**
 	 * A unique identifier that associates the trigger with a content.
 	 */
-	value: string;
+	value: T;
 }
 
-export interface TabsReturn {
+export interface TabsReturn<T extends string> {
 	/**
 	 * Activates tab.
 	 */
-	activate: (value: string) => void;
+	activate: (value: T) => void;
 
 	/**
 	 * The active tab.
 	 */
-	active: Readable<string>;
+	active: Readable<T>;
 
 	/**
 	 * Action for the tabs root element.
 	 */
-	useTabs: Action<HTMLElement, TabsParams>;
+	useTabs: Action<HTMLElement, TabsParams<T>>;
 
 	/**
 	 * HTML attributes for the element that contains the trigger and content elements.
@@ -79,10 +79,10 @@ export interface TabsReturn {
 	/**
 	 * HTML attributes for the trigger element.
 	 */
-	triggerAttrs: Readable<(params: TabsTriggerParams | string) => Record<string, string>>;
+	triggerAttrs: Readable<(params: TabsTriggerParams<T> | T) => Record<string, string>>;
 
 	/**
 	 * HTML attributes for the content element.
 	 */
-	contentAttrs: Readable<(params: TabsContentParams | string) => Record<string, string>>;
+	contentAttrs: Readable<(params: TabsContentParams<T> | T) => Record<string, string>>;
 }


### PR DESCRIPTION
Call with `createTabs<'tab1' | 'tab2' | 'tab3'>()`.