### PR TITLE
feat(@grail-ui/svelte): menu supports generic for items

### DIFF
--- a/.changeset/fifty-taxis-ring.md
+++ b/.changeset/fifty-taxis-ring.md
@@ -1,0 +1,5 @@
+---
+'@grail-ui/svelte': minor
+---
+
+Menu supports generic for item ids

--- a/apps/docs/src/lib/modules/menu/demos/MenuDemo.svelte
+++ b/apps/docs/src/lib/modules/menu/demos/MenuDemo.svelte
@@ -3,7 +3,7 @@
 	import { fade } from 'svelte/transition';
 
 	const { useTrigger, triggerAttrs, useMenu, menuAttrs, itemAttrs, open } = createMenu({
-		onSelect(id: string) {
+		onSelect(id) {
 			$open = false;
 			alert(id);
 		},

--- a/packages/grail-ui/src/menu/__tests__/MenuTest.svelte
+++ b/packages/grail-ui/src/menu/__tests__/MenuTest.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { MenuReturn } from '../menu.types';
 
-	export let api: MenuReturn;
+	export let api: MenuReturn<string>;
 	export let triggerExists = true;
 
 	const { useTrigger, triggerAttrs, useMenu, menuAttrs, itemAttrs, separatorAttrs, open } = api;

--- a/packages/grail-ui/src/menu/__tests__/menu.test.ts
+++ b/packages/grail-ui/src/menu/__tests__/menu.test.ts
@@ -1,4 +1,3 @@
-import type { MenuReturn } from '../menu.types';
 import { vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
@@ -17,7 +16,7 @@ vi.stubGlobal('ResizeObserver', ResizeObserver);
 describe('Menu', () => {
 	const user = userEvent.setup();
 
-	function setup(api: MenuReturn = createMenu()) {
+	function setup(api = createMenu()) {
 		const { container, component } = render(MenuTest, { api });
 		const trigger = screen.getByTestId('trigger');
 

--- a/packages/grail-ui/src/menu/menu.ts
+++ b/packages/grail-ui/src/menu/menu.ts
@@ -16,14 +16,14 @@ import { writableEffect } from '../util/store';
 const getMenuItems = (parent: HTMLElement) =>
 	Array.from(parent.querySelectorAll<HTMLElement>('[role=menuitem]'));
 
-export const createMenu = ({
+export const createMenu = <T extends string>({
 	positioning = {},
 	open = false,
 	portal = null,
 	onOpenChange,
 	ariaLabel = 'Menu',
 	onSelect,
-}: MenuConfig = {}): MenuReturn => {
+}: MenuConfig<T> = {}): MenuReturn<T> => {
 	const id = uniqueId('menu');
 	const getTrigger = () => document.getElementById(id) as HTMLElement | null;
 
@@ -63,7 +63,7 @@ export const createMenu = ({
 	});
 
 	const itemAttrs = derived(keyManager.activeItem, ($activeItem) => {
-		return function (attrs: string | { id: string; label: string }) {
+		return function (attrs: T | { id: T; label: string }) {
 			const { id: _id, label } = typeof attrs === 'string' ? { id: attrs, label: attrs } : attrs;
 			const itemId = `${id}_item_${_id}`;
 
@@ -177,7 +177,7 @@ export const createMenu = ({
 			if (target instanceof HTMLElement && target.getAttribute('role') === 'menuitem') {
 				event.preventDefault();
 				if (!skipPredicate(target)) {
-					onSelect(target.getAttribute('data-item-id') as string);
+					onSelect(target.getAttribute('data-item-id') as T);
 				}
 			}
 		};

--- a/packages/grail-ui/src/menu/menu.types.ts
+++ b/packages/grail-ui/src/menu/menu.types.ts
@@ -2,7 +2,7 @@ import type { Action } from 'svelte/action';
 import type { Readable, Writable } from 'svelte/store';
 import type { PositioningOptions } from '../floating/floating.types';
 
-export type MenuConfig = {
+export type MenuConfig<T extends string = string> = {
 	/**
 	 * The open state of the popover when it is initially rendered.
 	 *
@@ -40,10 +40,10 @@ export type MenuConfig = {
 	/**
 	 * Event handler called when an item is selected.
 	 */
-	onSelect?: (value: string) => void | undefined;
+	onSelect?: (value: T) => void | undefined;
 };
 
-export type MenuReturn = {
+export type MenuReturn<T extends string> = {
 	/**
 	 * Action for the trigger element.
 	 */
@@ -67,7 +67,7 @@ export type MenuReturn = {
 	/**
 	 * HTML attributes for the menu item element.
 	 */
-	itemAttrs: Readable<(params: string | { id: string; label: string }) => Record<string, string>>;
+	itemAttrs: Readable<(params: T | { id: T; label: string }) => Record<string, string>>;
 
 	/**
 	 * HTML attributes for the element that is used to visually separate menu items.


### PR DESCRIPTION
Call with `createMenu<'item1' | 'item2' | 'item3'>()`.