### PR TITLE
refactor(@grail-ui/svelte): remove destroy "safety" on modal

### DIFF
--- a/packages/grail-ui/src/modal/modal.ts
+++ b/packages/grail-ui/src/modal/modal.ts
@@ -73,15 +73,8 @@ export const createModal = ({
 			}
 		});
 
-		let destroyed = false;
 		return {
 			destroy() {
-				// Make sure that destroy is not called twice
-				if (destroyed) {
-					return;
-				}
-				destroyed = true;
-
 				focusTrapAction?.destroy?.();
 				portalAction?.destroy?.();
 				clickOutsideAction?.destroy?.();


### PR DESCRIPTION
This is fixed upstream.