### PR TITLE
fix(docs): import createModal from modal module

### DIFF
--- a/apps/docs/src/routes/(app)/(sidebar)/svelte/getting-started/+page.svelte
+++ b/apps/docs/src/routes/(app)/(sidebar)/svelte/getting-started/+page.svelte
@@ -31,7 +31,7 @@
 		If you are unable to use tree shaking, you can still selectively include only the specific
 		modules that you need by importing them directly, like this:
 		<Highlight
-			source={`import { createModal } from "@grail-ui/svelte/accordion";
+			source={`import { createModal } from "@grail-ui/svelte/modal";
 import { createTooltip } from "@grail-ui/svelte/tooltip";`}
 			class="rounded"
 		/>


### PR DESCRIPTION
The above paragraph talks about modal and tooltip, so I chose `import { createModal } from "@grail-ui/svelte/modal"` instead of `import { createAccordion } from "@grail-ui/svelte/accordion"` for consistency.