### PR TITLE
fix(@grail-ui/svelte): fix accordion expandAll

### DIFF
--- a/packages/grail-ui/src/accordion/accordion.ts
+++ b/packages/grail-ui/src/accordion/accordion.ts
@@ -160,7 +160,9 @@ export function createAccordion<T extends string = string>(
 
 	const expandAll = () => {
 		if (rootNode) {
-			getTriggers(rootNode).forEach(toggleTrigger);
+			const keys = getTriggers(rootNode)
+				.map((trigger) => trigger.dataset.accordionTrigger as T);
+			select(...keys);
 		}
 	};
 


### PR DESCRIPTION
expandAll should `select` all trigger keys, not just toggle them